### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/IO/Capture/Simple.pm
+++ b/lib/IO/Capture/Simple.pm
@@ -1,4 +1,4 @@
-module IO::Capture::Simple;
+unit module IO::Capture::Simple;
 
 my $stdout = $*OUT;
 my $stderr = $*ERR;

--- a/lib/Test/IO/Capture.pm
+++ b/lib/Test/IO/Capture.pm
@@ -1,7 +1,7 @@
 use Test;
 use IO::Capture::Simple;
 
-module Test::IO::Capture;
+unit module Test::IO::Capture;
 
 sub prints-stdout-ok (Callable $code, $expected as Str, $reason = '')
 is export {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.