### PR TITLE
Replace removed feature 'as' keyword

### DIFF
--- a/lib/Test/IO/Capture.pm
+++ b/lib/Test/IO/Capture.pm
@@ -3,13 +3,13 @@ use IO::Capture::Simple;
 
 unit module Test::IO::Capture;
 
-sub prints-stdout-ok (Callable $code, $expected as Str, $reason = '')
+sub prints-stdout-ok (Callable $code, Str $expected, $reason = '')
 is export {
     my $out = capture_stdout $code;
     is $out, $expected, $reason;
 }
 
-sub prints-stderr-ok (Callable $code, $expected as Str, $reason = '')
+sub prints-stderr-ok (Callable $code, Str $expected, $reason = '')
 is export {
     my $out = capture_stderr $code;
     is $out, $expected, $reason;


### PR DESCRIPTION
IO::Capture::Simple cannot be compiled with latest rakudo as below.

```
% prove -rv -e 'perl6 -Ilib' t/test-io-capture/01-basic.t
t/test-io-capture/01-basic.t .. ===SORRY!=== Error while compiling /home/syohei/.cpanm/work/1450767019.20953/IO-Capture-Simple/lib/Test/IO/Capture.pm
Malformed parameter
at /home/syohei/.cpanm/work/1450767019.20953/IO-Capture-Simple/lib/Test/IO/Capture.pm:6
------> nts-stdout-ok (Callable $code, $expected⏏ as Str, $reason = '')
    expecting any of:
        constraint
===SORRY!=== Error while compiling /home/syohei/.cpanm/work/1450767019.20953/IO-Capture-Simple/lib/Test/IO/Capture.pm
Malformed parameter
at /home/syohei/.cpanm/work/1450767019.20953/IO-Capture-Simple/lib/Test/IO/Capture.pm:6
------> nts-stdout-ok (Callable $code, $expected⏏ as Str, $reason = '')
    expecting any of:
        constraint
```